### PR TITLE
Update body-font

### DIFF
--- a/src/css/parts/root.css
+++ b/src/css/parts/root.css
@@ -100,10 +100,10 @@
 	--header-subtitle: "確保、収容、保護";
 
 	/* ===TYPEFACES=== */
-	--body-font: Inter, "M Plus 1p", sans-serif;
+	--body-font: Inter, "BIZ UDPGothic", "M Plus 1p", sans-serif;
 	--UI-font: PTRootUI, sans-serif;
-	--header-font: var(--body-font);
-	--title-font: var(--body-font);
+	--header-font: Inter, "M Plus 1p", sans-serif;
+	--title-font: var(--header-font);
 	--mono-font: Recursive, monospace;
 
 	/* ===BASE FONT SIZE & LINE HEIGHT=== */


### PR DESCRIPTION

![スクリーンショット 2024-02-29 103351](https://github.com/SCP-JP/Black-Highlighter/assets/1701388/40bb61ce-5af7-4aef-87b3-008e4b5120ba)

BHLテーマで使用しているM PLUS 1pフォントは、フォントサイズが20px以下だとジャギーが発生するらしい
そのため、少なくともWindows環境下ではBHLテーマの適用された記事の本文が汚く見える（添付の画像では「オ」「去」のような文字で線が部分的に太くなっているのが確認できる）

参考: M PLUS Rounded 1cが汚いけどCSS追記でキレイに表示させる
https://tips.back2nature.jp/css/m-plus-rounded-1c-is-dirty-but-it-is-displayed-neatly-by-adding-css/

上記リンクではrotateで文字に回転をかけて黒魔術的に対処しているが、この対処法を試してみると、全体的に字がうっすらとかすれて見えるため、あまり良い解決策には思えないように感じた

Windows 10以降に内蔵されている視認性の高いフォントとして、BIZ UDPゴシックを指定することにした
メイリオと違い斜体にも対応している
ただし、BIZ UDPゴシックは極太のウェイトに対応しておらず、ヘッダーに使うと違和感が強くて使えないので、ヘッダー表示には引き続き M PLUS 1pを使用する

まとめ:
Windowsでは本文の表示にBIZ UDPゴシックを使うように指定を追加した

サンプル:
![スクリーンショット 2024-02-29 103342](https://github.com/SCP-JP/Black-Highlighter/assets/1701388/85de2522-6264-4284-b57e-3a12d854d43d)
